### PR TITLE
Added ability to preview local png,jpg and gif images.

### DIFF
--- a/instant-markdown-d
+++ b/instant-markdown-d
@@ -24,6 +24,14 @@ function httpHandler(req, res) {
          .pipe(res);
         return;
       }
+      var githubUrlRelative = req.url.match(/(.+(?:\.png|\.jpg|\.gif)$)/);
+      if (githubUrlRelative) {
+         // Serve the file out of the current working directory
+        send(req, githubUrlRelative[1])
+         .root(process.cwd())
+         .pipe(res);
+        return;
+      }
 
       // Otherwise serve the file from the directory this module is in
       send(req, req.url)


### PR DESCRIPTION
I added the ability to preview relatively referenced images (png, jpg, and gif).  There was a regex condition that would display an image referenced from the root of github, but I wanted to also display images will relative links which as I understand is also supported by github.
