### PR TITLE
will serve images from the current working directory

### DIFF
--- a/index.css
+++ b/index.css
@@ -1,0 +1,248 @@
+/* 
+   Some simple Github-like styles, with syntax highlighting CSS via Pygments.
+*/
+html {
+	background:#fff;
+	margin:0;
+	padding:0;
+}
+body {
+	font: 14px helvetica,arial,freesans,clean,sans-serif;
+	line-height: 1.6;
+	margin: 0 auto;
+    padding: 20px;
+	text-align:left;
+	color: #333;
+    max-width: 100%;
+}
+
+.md {
+	background-color: #eee;
+	border-radius:3px;
+    margin: 0;
+    padding: 0;
+}
+
+article {
+  padding: 30px;
+  background-color: white;
+}
+article > :first-child {
+  margin-top: 0!important;
+}
+
+h1 {
+	font-size:28px;
+	margin-bottom:10px;
+  color: black;
+}
+
+h2 {
+	font-size:24px;
+	margin:20px 0 10px;
+  color: black;
+  border-bottom: 1px solid #ccc;
+}
+
+h3 {
+	font-size:18px;
+	margin:20px 0 10px;
+}
+
+h4 {
+	font-size:16px;
+	font-weight:bold;
+	margin:20px 0 10px;
+}
+
+h5 {
+	font-size:14px;
+	font-weight:bold;
+	margin:20px 0 10px;
+}
+
+h6 {
+	color:#777;
+	font-size:14px;
+	font-weight:bold;
+	margin:20px 0 10px;
+}
+
+hr {
+	background: transparent url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAYAAAAECAYAAACtBE5DAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyJpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuMC1jMDYwIDYxLjEzNDc3NywgMjAxMC8wMi8xMi0xNzozMjowMCAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNSBNYWNpbnRvc2giIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6OENDRjNBN0E2NTZBMTFFMEI3QjRBODM4NzJDMjlGNDgiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6OENDRjNBN0I2NTZBMTFFMEI3QjRBODM4NzJDMjlGNDgiPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDo4Q0NGM0E3ODY1NkExMUUwQjdCNEE4Mzg3MkMyOUY0OCIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDo4Q0NGM0E3OTY1NkExMUUwQjdCNEE4Mzg3MkMyOUY0OCIvPiA8L3JkZjpEZXNjcmlwdGlvbj4gPC9yZGY6UkRGPiA8L3g6eG1wbWV0YT4gPD94cGFja2V0IGVuZD0iciI/PqqezsUAAAAfSURBVHjaYmRABcYwBiM2QSA4y4hNEKYDQxAEAAIMAHNGAzhkPOlYAAAAAElFTkSuQmCC) repeat-x 0 0;
+	border: 0 none;
+	height: 4px;
+	margin: 15px 0;
+	padding: 0;
+}
+
+
+p {
+	margin: 15px 0; 
+}
+
+pre, code {
+	font: 12px 'Bitstream Vera Sans Mono','Courier',monospace;
+}
+.highlight pre, pre {
+	background-color:#f8f8f8;
+	border:1px solid #ccc;
+	font-size:13px;
+	line-height:19px;
+	overflow:auto;
+	border-radius:3px;
+	-moz-border-radius:3px;
+	-webkit-border-radius:3px;
+	padding:6px 10px;
+}
+
+
+
+code {
+	white-space:nowrap;
+	border:1px solid #eaeaea;
+	background-color:#f8f8f8;
+	border-radius:3px;
+	-moz-border-radius:3px;
+	-webkit-border-radius:3px;
+	margin:0 2px;
+	padding:0 5px;
+}
+
+pre>code
+{
+	white-space:pre;
+	border:none;
+	background:transparent;
+	margin:0;
+	padding:0;
+}
+
+a, a code {
+	color: #4183C4;
+	text-decoration:none;
+}
+
+
+blockquote
+{
+	border-left:4px solid #ddd;
+	padding-left:11px;
+	color:#555;
+	margin:14px 0;
+}
+
+table
+{
+  font-size: 14px;
+	border-collapse:collapse;
+	margin:20px 0 0;
+	padding:0;
+}
+
+table tr
+{
+	border-top:1px solid #ccc;
+	background-color:#fff;
+	margin:0;
+	padding:0;
+}
+
+table tr:nth-child(2n)
+{
+	background-color:#f8f8f8;
+}
+table tr th[align="center"], table tr td[align="center"] {
+	text-align:center;
+}
+table tr th, table tr td
+{
+	border:1px solid #ccc;
+	text-align:left;
+	margin:0;
+	padding:6px 13px;
+}
+
+ul, ol
+{
+	margin:15px 0;
+}
+
+ul li, ol li
+{
+	margin-top:7px;
+	margin-bottom:7px;
+}
+
+
+
+.shadow {
+	-webkit-box-shadow:0 5px 15px #000;
+	-moz-box-shadow:0 5px 15px #000;
+	box-shadow:0 5px 15px #000;		
+}
+
+
+
+/* Pygments coloring */
+.highlight .c{color:#998;font-style:italic;}
+.highlight .err{color:#a61717;background-color:#e3d2d2;}
+.highlight .k{font-weight:bold;}
+.highlight .o{font-weight:bold;}
+.highlight .cm{color:#998;font-style:italic;}
+.highlight .cp{color:#999;font-weight:bold;}
+.highlight .c1{color:#998;font-style:italic;}
+.highlight .cs{color:#999;font-weight:bold;font-style:italic;}
+.highlight .gd{color:#000;background-color:#fdd;}
+.highlight .gd .x{color:#000;background-color:#faa;}
+.highlight .ge{font-style:italic;}
+.highlight .gr{color:#a00;}
+.highlight .gh{color:#999;}
+.highlight .gi{color:#000;background-color:#dfd;}
+.highlight .gi .x{color:#000;background-color:#afa;}
+.highlight .go{color:#888;}
+.highlight .gp{color:#555;}
+.highlight .gs{font-weight:bold;}
+.highlight .gu{color:#800080;font-weight:bold;}
+.highlight .gt{color:#a00;}
+.highlight .kc{font-weight:bold;}
+.highlight .kd{font-weight:bold;}
+.highlight .kn{font-weight:bold;}
+.highlight .kp{font-weight:bold;}
+.highlight .kr{font-weight:bold;}
+.highlight .kt{color:#458;font-weight:bold;}
+.highlight .m{color:#099;}
+.highlight .s{color:#d14;}
+.highlight .na{color:#008080;}
+.highlight .nb{color:#0086B3;}
+.highlight .nc{color:#458;font-weight:bold;}
+.highlight .no{color:#008080;}
+.highlight .ni{color:#800080;}
+.highlight .ne{color:#900;font-weight:bold;}
+.highlight .nf{color:#900;font-weight:bold;}
+.highlight .nn{color:#555;}
+.highlight .nt{color:#000080;}
+.highlight .nv{color:#008080;}
+.highlight .ow{font-weight:bold;}
+.highlight .w{color:#bbb;}
+.highlight .mf{color:#099;}
+.highlight .mh{color:#099;}
+.highlight .mi{color:#099;}
+.highlight .mo{color:#099;}
+.highlight .sb{color:#d14;}
+.highlight .sc{color:#d14;}
+.highlight .sd{color:#d14;}
+.highlight .s2{color:#d14;}
+.highlight .se{color:#d14;}
+.highlight .sh{color:#d14;}
+.highlight .si{color:#d14;}
+.highlight .sx{color:#d14;}
+.highlight .sr{color:#009926;}
+.highlight .s1{color:#d14;}
+.highlight .ss{color:#990073;}
+.highlight .bp{color:#999;}
+.highlight .vc{color:#008080;}
+.highlight .vg{color:#008080;}
+.highlight .vi{color:#008080;}
+.highlight .il{color:#099;}
+

--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <link rel="stylesheet" type="text/css" href="/node_modules/docter/ghf_marked.css" />
+  <link rel="stylesheet" type="text/css" href="/index.css" />
   <script src="/socket.io/socket.io.js"></script>
 
   <script type="text/x-mathjax-config">

--- a/index.html
+++ b/index.html
@@ -3,11 +3,18 @@
   <meta charset="utf-8">
   <link rel="stylesheet" type="text/css" href="/node_modules/docter/ghf_marked.css" />
   <script src="/socket.io/socket.io.js"></script>
+
+  <script type="text/x-mathjax-config">
+    MathJax.Hub.Config({ tex2jax: { inlineMath: [['$','$'], ["\\(","\\)"]], processEscapes: true } });
+  </script>
+  <script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+
   <script>
     var socket = io.connect('http://localhost:8090/');
     socket.on('connect', function () {
       socket.on('newContent', function(newHTML) {
         document.body.innerHTML = newHTML;
+        MathJax.Hub.Queue(['Typeset', MathJax.Hub]);
       });
       socket.on('die', function(newHTML) {
         window.open('', '_self', '');

--- a/instant-markdown-d
+++ b/instant-markdown-d
@@ -17,16 +17,7 @@ function httpHandler(req, res) {
     case 'GET':
       // Example: /my-repo/raw/master/sub-dir/some.png
       var githubUrl = req.url.match(/\/[^\/]+\/raw\/[^\/]+\/(.+)/),
-          img_exts = ['.png', '.jpg', '.jpeg', '.gif'],
-          is_img = false;
-
-      // Check if an image is requested.
-      for (var i=0; i<img_exts.length; i++) {
-        if (req.url.indexOf(img_exts[i]) !== -1) {
-            is_img = true;
-            break;
-        }
-      }
+          is_img = req.url.match(/(.+(?:\.png|\.jpg|\.jpeg|\.gif)$)/);
 
       if (githubUrl || is_img) {
          // Serve the file out of the current working directory

--- a/instant-markdown-d
+++ b/instant-markdown-d
@@ -16,8 +16,19 @@ function httpHandler(req, res) {
   {
     case 'GET':
       // Example: /my-repo/raw/master/sub-dir/some.png
-      var githubUrl = req.url.match(/\/[^\/]+\/raw\/[^\/]+\/(.+)/);
-      if (githubUrl) {
+      var githubUrl = req.url.match(/\/[^\/]+\/raw\/[^\/]+\/(.+)/),
+          img_exts = ['.png', '.jpg', '.jpeg', '.gif'],
+          is_img = false;
+
+      // Check if an image is requested.
+      for (var i=0; i<img_exts.length; i++) {
+        if (req.url.indexOf(img_exts[i]) !== -1) {
+            is_img = true;
+            break;
+        }
+      }
+
+      if (githubUrl || is_img) {
          // Serve the file out of the current working directory
         send(req, githubUrl[1])
          .root(process.cwd())


### PR DESCRIPTION
A feature requested here:
https://github.com/suan/vim-instant-markdown/issues/34
is that images be supported in vim-instant-markdown. This PR makes it so that if a requested url has a common image file extension, it is served from the current working directory.
