### PR TITLE
replace docter with markdown-it

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ instant-markdown-d is a small Node.js server that enables instant compilation an
 
 Installation
 ------------
-- `[sudo] gem install redcarpet pygments.rb`
 - `[sudo] npm -g install instant-markdown-d`
 
 REST API
@@ -15,10 +14,3 @@ REST API
 | Close Webpage    | DELETE      | http://localhost:\<port\> | |
 
 By default, `<port>` is 8090
-
-Credits
--------
-Aaron Lampros's [Docter][docter], which is the underlying Markdown converter and styler.
-
-
-[docter]: https://github.com/alampros/Docter

--- a/index.html
+++ b/index.html
@@ -1,13 +1,22 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <link rel="stylesheet" type="text/css" href="/node_modules/docter/ghf_marked.css" />
+  <link rel="stylesheet" type="text/css" href="/node_modules/highlight.js/styles/github.css">
+  <link rel="stylesheet" type="text/css" href="/node_modules/github-markdown-css/github-markdown.css">
+  <style>
+    .markdown-body {
+      min-width: 200px;
+      max-width: 790px;
+      margin: 0 auto;
+      padding: 30px;
+    }
+  </style>
   <script src="/socket.io/socket.io.js"></script>
   <script>
     var socket = io.connect('http://localhost:8090/');
     socket.on('connect', function () {
       socket.on('newContent', function(newHTML) {
-        document.body.innerHTML = newHTML;
+        document.querySelector(".markdown-body").innerHTML = newHTML;
       });
       socket.on('die', function(newHTML) {
         window.open('', '_self', '');
@@ -23,5 +32,6 @@
   </script>
 </head>
 <body>
+  <article class="markdown-body"></article>
 </body>
 </html>

--- a/instant-markdown-d
+++ b/instant-markdown-d
@@ -32,8 +32,11 @@ function writeMarkdown(input, output) {
   });
   input.on('end', function() {
     marked(body, function(err, content) {
-      if (err) { throw err; }
-      output.emit('newContent', content);
+      if (!err) {
+        output.emit('newContent', content);
+      } else {
+        console.error(err);
+      }
     });
   });
 }

--- a/instant-markdown-d
+++ b/instant-markdown-d
@@ -1,15 +1,42 @@
 #!/bin/sh
 ':' //; exec "`command -v nodejs || command -v node`" "$0"
 
+var marked = require('marked');
+var hljs = require('highlight.js');
 var server = require('http').createServer(httpHandler),
-    spawn = require('child_process').spawn,
     exec = require('child_process').exec,
     io = require('socket.io').listen(server),
     send = require('send'),
     server,
     socket;
 
+marked.setOptions({
+  highlight: function(code, lang) {
+    if (lang) {
+      return hljs.highlight(lang, code).value;
+    } else {
+      return hljs.highlightAuto(code).value;
+    }
+  }
+});
+
 server.listen(8090);
+
+function writeMarkdown(input, output) {
+  var body = '';
+  input.on('data', function(data) {
+    body += data;
+    if (body.length > 1e6) {
+      throw new Error('The request body is too long.');
+    }
+  });
+  input.on('end', function() {
+    marked(body, function(err, content) {
+      if (err) { throw err; }
+      output.emit('newContent', content);
+    });
+  });
+}
 
 function httpHandler(req, res) {
   switch(req.method)
@@ -45,22 +72,9 @@ function httpHandler(req, res) {
       break;
 
     case 'PUT':
-      var newHTML = '';
-      var gfm = spawn(__dirname + '/node_modules/docter/bin/github-flavored-markdown.rb', ['--unstyled']);
-      req.on('data', function(chunk){
-        gfm.stdin.write(chunk);
-      });
-      req.on('end', function(){
-        gfm.stdin.end();
-        res.writeHead(200);
-        res.end();
-      });
-      gfm.stdout.on('data', function(data) {
-        newHTML += data;
-      });
-      gfm.on('exit',function(ecode){
-        socket.emit('newContent', newHTML);
-      });
+      writeMarkdown(req, socket);
+      res.writeHead(200);
+      res.end();
       break;
 
     default:
@@ -71,21 +85,7 @@ io.set('log level', 1);
 io.sockets.on('connection', function(sock){
   socket = sock;
   process.stdout.write('connection established!');
-
-  var newHTML = '';
-  var gfm = spawn(__dirname + '/node_modules/docter/bin/github-flavored-markdown.rb', ['--unstyled']);
-  process.stdin.on('data', function(chunk){
-    gfm.stdin.write(chunk);
-  });
-  process.stdin.on('end', function(){
-    gfm.stdin.end();
-  });
-  gfm.stdout.on('data', function(data) {
-    newHTML += data;
-  });
-  gfm.on('exit',function(ecode){
-    socket.emit('newContent', newHTML);
-  });
+  writeMarkdown(process.stdin, socket);
   process.stdin.resume();
 });
 

--- a/instant-markdown-d
+++ b/instant-markdown-d
@@ -1,7 +1,7 @@
 #!/bin/sh
 ':' //; exec "`command -v nodejs || command -v node`" "$0"
 
-var marked = require('marked');
+var MarkdownIt = require('markdown-it');
 var hljs = require('highlight.js');
 var server = require('http').createServer(httpHandler),
     exec = require('child_process').exec,
@@ -10,17 +10,28 @@ var server = require('http').createServer(httpHandler),
     server,
     socket;
 
-marked.setOptions({
-  highlight: function(code, lang) {
-    if (lang) {
-      return hljs.highlight(lang, code).value;
-    } else {
-      return hljs.highlightAuto(code).value;
+server.listen(8090);
+
+var md = new MarkdownIt({
+  html: true,
+  linkify: true,
+  highlight: function(str, lang) {
+    if (lang && hljs.getLanguage(lang)) {
+      try {
+        return hljs.highlight(lang, str).value;
+      } catch (err) {
+        // Do nothing
+      }
     }
+
+    try {
+      return hljs.highlightAuto(str).value;
+    } catch (err) {
+      // Do nothing
+    }
+    return '';
   }
 });
-
-server.listen(8090);
 
 function writeMarkdown(input, output) {
   var body = '';
@@ -31,13 +42,7 @@ function writeMarkdown(input, output) {
     }
   });
   input.on('end', function() {
-    marked(body, function(err, content) {
-      if (!err) {
-        output.emit('newContent', content);
-      } else {
-        console.error(err);
-      }
-    });
+    output.emit('newContent', md.render(body));
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -1,17 +1,19 @@
 {
-	"author": "Suan-Aik Yeo <yeosuanaik@gmail.com>",
-	"name": "instant-markdown-d",
-	"description": "Instantly-updating Markdown Server",
-	"version": "0.0.8",
-	"engine" : "node",
-	"main": "instant-markdown-d",
-  "preferGlobal" : "true",
-	"bin" : { 
-		"instant-markdown-d" : "./instant-markdown-d"
-	},
-	"dependencies": {
-    "socket.io": "",
-    "docter": "https://github.com/suan/Docter/tarball/master",
-    "send": "~0.1.0"
+  "author": "Suan-Aik Yeo <yeosuanaik@gmail.com>",
+  "name": "instant-markdown-d",
+  "description": "Instantly-updating Markdown Server",
+  "version": "0.0.8",
+  "engine": "node",
+  "main": "instant-markdown-d",
+  "preferGlobal": "true",
+  "bin": {
+    "instant-markdown-d": "./instant-markdown-d"
+  },
+  "dependencies": {
+    "github-markdown-css": "^2.0.2",
+    "highlight.js": "^8.4.0",
+    "marked": "^0.3.2",
+    "send": "~0.1.0",
+    "socket.io": ""
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "github-markdown-css": "^2.0.2",
     "highlight.js": "^8.4.0",
-    "marked": "^0.3.2",
+    "markdown-it": "^3.0.3",
     "send": "~0.1.0",
     "socket.io": ""
   }


### PR DESCRIPTION
Docter has problems with indented code blocks (no HTML is output). It also adds an unnecessary ruby dependency. This commit replaces docter with the pure-javascript marked module. It also slightly improves the rendering of the output.

Closes #10, suan/vim-instant-markdown#60, suan/vim-instant-markdown#55, perhaps others.