### PR TITLE
Serve arbitrary urls from the current directory as well

### DIFF
--- a/instant-markdown-d
+++ b/instant-markdown-d
@@ -45,19 +45,27 @@ function httpHandler(req, res) {
   switch(req.method)
   {
     case 'GET':
-      // Example: /my-repo/raw/master/sub-dir/some.png
-      var githubUrl = req.url.match(/\/[^\/]+\/raw\/[^\/]+\/(.+)/);
-      if (githubUrl) {
-         // Serve the file out of the current working directory
-        send(req, githubUrl[1])
-         .root(process.cwd())
-         .pipe(res);
-        return;
+      // By default, serve files from current working directory (e.g.
+      // next to the markdown file)
+      var url = req.url;
+      var root = process.cwd();
+
+      // Except for a few files we need to serve from the module
+      // directory
+      var package_urls = ["/", "/index.html", "/github-markdown.css", "/github-syntax-highlight.css"];
+      if (package_urls.indexOf(url) >= 0) {
+        root = __dirname;
       }
 
-      // Otherwise serve the file from the directory this module is in
-      send(req, req.url)
-        .root(__dirname)
+      // Support absolute urls to github files (no longer required,
+      // github now also supports relative urls, but for compatibility
+      // with older documents). Example: /my-repo/raw/master/sub-dir/some.png
+      var match = req.url.match(/\/[^\/]+\/raw\/[^\/]+\/(.+)/);
+      if (match)
+        url = match[1];
+
+      send(req, url)
+        .root(root)
         .pipe(res);
       break;
 


### PR DESCRIPTION
Previously, only github-style absolute urls (containing /raw/) were
served from the current directory and all others were served from the
module directory.

With this change, only the handful of urls that actually exist in the
module directory are served from there, all others are served from the
current directory. This should make sure that linking to images or
other resources in a markdown document works as you expect it to.

Any /raw/ urls are still detected and modified to still work (stripping
the fixed prefix, leaving only the relative link) as well.

This commit is based on #11 by David Bankier dbankier@hotmail.com, but
pretty much changes all of the code.

This PR replaces #11, #12 and #14 with, IMHO a more elegant and complete implementation, with the added bonus of cleanly applying on the current git master.
