### PR TITLE
Add '--browser' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,10 @@ REST API
 | Close Webpage    | DELETE      | http://localhost:\<port\> | |
 
 By default, `<port>` is 8090
+
+Prefered browser
+----------------
+By default, instant-markdown-d will use the default browser, if you want to
+use an another browser, you can pass the `browser` option:
+
+- `instant-markdown-d --browser=google-chrome`

--- a/instant-markdown-d
+++ b/instant-markdown-d
@@ -1,5 +1,5 @@
 #!/bin/sh
-':' //; exec "`command -v nodejs || command -v node`" "$0"
+':' //; exec "`command -v nodejs || command -v node`" "$0" "$*"
 
 var MarkdownIt = require('markdown-it');
 var hljs = require('highlight.js');
@@ -8,7 +8,8 @@ var server = require('http').createServer(httpHandler),
     io = require('socket.io').listen(server),
     send = require('send'),
     server,
-    socket;
+    socket,
+    argv = require('optimist').argv;
 
 server.listen(8090);
 
@@ -92,10 +93,15 @@ io.sockets.on('connection', function(sock){
   process.stdin.resume();
 });
 
+var openCommand;
+if (argv.browser === undefined) {
+  if (process.platform.toLowerCase().indexOf('darwin') >= 0) {
+    openCommand = 'open -g http://localhost:8090';
+  } else { // assume unix/linux
+    openCommand = 'xdg-open http://localhost:8090';
+  }
+} else {
+  openCommand = argv.browser + ' http://localhost:8090';
+}
 
-if (process.platform.toLowerCase().indexOf('darwin') >= 0){
-  exec('open -g http://localhost:8090', function(error, stdout, stderr){});
-}
-else {  // assume unix/linux
-  exec('xdg-open http://localhost:8090', function(error, stdout, stderr){});
-}
+exec(openCommand, function(error, stdout, stderr){});

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "highlight.js": "^8.4.0",
     "markdown-it": "^3.0.3",
+    "optimist": "~0.6.1",
     "send": "~0.1.0",
     "socket.io": ""
   }


### PR DESCRIPTION
It allows to use instant-markdown-d with '--browser' option, e.g:

```
$ ./instant-markdown-d --browser=google-chrome
$ ./instant-markdown-d --browser=firefox
```

Also I'll create pull request for vim-instant-markdown.
