### PR TITLE
Add command line option to instant-markdown-d for custom script

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,12 @@ REST API
 | Close Webpage    | DELETE      | http://localhost:\<port\> | |
 
 By default, `<port>` is 8090
+
+Preview page appearance
+-----------------------
+(Currently only supported on OS X)
+
+instant-markdown-d can be passed the full path of a script to execute right
+after the preview page is launched. On OS X, for example, an AppleScript can be
+used to change the size and position of the preview page On OS X, for example,
+an AppleScript can be used to change the size and position of the preview page.

--- a/README.md
+++ b/README.md
@@ -21,5 +21,4 @@ Preview page appearance
 
 instant-markdown-d can be passed the full path of a script to execute right
 after the preview page is launched. On OS X, for example, an AppleScript can be
-used to change the size and position of the preview page On OS X, for example,
-an AppleScript can be used to change the size and position of the preview page.
+used to change the size and position of the preview page.

--- a/instant-markdown-d
+++ b/instant-markdown-d
@@ -1,5 +1,7 @@
 #!/bin/sh
-':' //; exec "`command -v nodejs || command -v node`" "$0"
+':' //; exec "`command -v nodejs || command -v node`" "$0" "$1"
+
+var custom_script = process.argv[2];
 
 var MarkdownIt = require('markdown-it');
 var hljs = require('highlight.js');
@@ -95,6 +97,9 @@ io.sockets.on('connection', function(sock){
 
 if (process.platform.toLowerCase().indexOf('darwin') >= 0){
   exec('open -g http://localhost:8090', function(error, stdout, stderr){});
+  if(custom_script) {
+    exec('osascript '.concat(custom_script));
+  }
 }
 else {  // assume unix/linux
   exec('xdg-open http://localhost:8090', function(error, stdout, stderr){});


### PR DESCRIPTION
See comments on related [pull request](https://github.com/suan/vim-instant-markdown/pull/71).

In few words, allow a custom script to be executed when the preview page is launched. This can be used to customize page appearance (see [example](https://github.com/AlessandroA/vim-instant-markdown/blob/master/README.md#ginstant_markdown_script))