### PR TITLE
move window scrollTop position to marker if marker exists

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,10 +16,26 @@
   </style>
   <script src="/socket.io/socket.io.js"></script>
   <script>
+
+    var SCROLL_PADDING = 100;
+    var cumulativeOffset = function(element) {
+        var top = 0, left = 0;
+        do {
+            top += element.offsetTop  || 0;
+            left += element.offsetLeft || 0;
+            element = element.offsetParent;
+        } while(element);
+        return { top: top, left: left };
+    };
+
     var socket = io.connect('http://'+ window.location.host +'/');
     socket.on('connect', function () {
       socket.on('newContent', function(newHTML) {
         document.querySelector(".markdown-body").innerHTML = newHTML;
+        var marker = document.querySelector("#marker");
+        if(marker) {
+          window.scrollTo(0, cumulativeOffset(marker).top - SCROLL_PADDING);
+        }
       });
       socket.on('die', function(newHTML) {
         window.open('', '_self', '');


### PR DESCRIPTION
If a marker element is on the page, this will scroll the window to the marker. It enables cursor syncing to the markdown document.

Dependent on https://github.com/suan/vim-instant-markdown/pull/74 for feature, but it's a progressive enhancement (nothing will break if this is pulled in before the other)
Resolves https://github.com/suan/vim-instant-markdown/issues/46
