### PR TITLE
There is no need to set these limits of width.

### DIFF
--- a/github-markdown.css
+++ b/github-markdown.css
@@ -121,11 +121,9 @@ td,th {
 
 .repository-with-sidebar .repository-content {
     /* float: left; */
-    width: 920px;
 }
 
 .repository-with-sidebar.with-full-navigation .repository-content {
-    width: 790px;
 }
 
 .repository-with-sidebar.with-full-navigation .repository-sidebar {

--- a/index.html
+++ b/index.html
@@ -9,7 +9,6 @@
   <style>
     .markdown-body {
       min-width: 200px;
-      max-width: 790px;
       margin: 0 auto;
       padding: 30px;
     }


### PR DESCRIPTION
This commit make it have the same width with github repository page and align centrally.
It looks better :)