### PR TITLE
mount current working directory to serve static files

### DIFF
--- a/instant-markdown-d
+++ b/instant-markdown-d
@@ -6,6 +6,7 @@ var server = require('http').createServer(httpHandler),
     exec = require('child_process').exec,
     io = require('socket.io').listen(server),
     os = require('os'),
+    fs = require('fs'),
     send = require('send');
 
 // WARNING: By setting this environment variable, anyone on your network may
@@ -103,9 +104,12 @@ function httpHandler(req, res) {
       var isIndexFile = /^\/(index\.html)?(\?|$)/.test(req.url);
       addSecurityHeaders(req, res, isIndexFile);
 
+      var cwd = process.cwd();
+      var mount = cwd && !fs.existsSync(__dirname + req.url) ? cwd : __dirname;
+
       // Otherwise serve the file from the directory this module is in
       send(req, req.url)
-        .root(__dirname)
+        .root(mount)
         .pipe(res);
       break;
 


### PR DESCRIPTION
## how?

if a file not exists at path of instant-markdown-d.
search it in current working directory.

## why?

This make it possible to handle image link correctly and solves these issues:

*   [(#34)I can't get images to show up](https://github.com/suan/vim-instant-markdown/issues/34)
*   [(#63)image link issue](https://github.com/suan/vim-instant-markdown/issues/63)
*   [(#83)Add demo gif as asset to repo](https://github.com/suan/vim-instant-markdown/pull/83)
*   [(#90)Do you have a plan to add support for image link?](https://github.com/suan/vim-instant-markdown/issues/90)


this should work:

```
▾ images/
    another-doge.png
  doge.png
  README.md
```

```
# README

![doge](doge.png)
![another-doge](images/another-doge.png)
```


