### PR TITLE
fix: req end event isn't called because res.end is called before

### DIFF
--- a/instant-markdown-d
+++ b/instant-markdown-d
@@ -203,9 +203,11 @@ function httpHandler(req, res) {
       break;
 
     case 'PUT':
-      readAllInput(req, writeMarkdown);
-      res.writeHead(200);
-      res.end();
+      readAllInput(req, function(body){
+        writeMarkdown(body);
+        res.writeHead(200);
+        res.end();
+      });
       break;
 
     default:


### PR DESCRIPTION
Fixing suan/vim-instant-markdown#171
I think due to change in HTTP low level implementation of Nodejs 10.x or 12.x but the orginal code is wrong because `res.end()` was called before events handling was done. So the `end` is never trigger in some nodejs implementation especially nodejs 12.x.

[This issue](https://github.com/nodejs/node/issues/2156#issuecomment-195676475) in nodejs repo confirm my thoughts.
We should implement the close event too.